### PR TITLE
sv -added application.properties file under test/resources to ignore the data.sql file during tests

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+#Ignore data.sql when running tests per https://stackoverflow.com/a/52104349
+spring.datasource.initialization-mode=never 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,5 @@
+spring.config.location=classpath:/
+@environment-properties@
+
 #Ignore data.sql when running tests per https://stackoverflow.com/a/52104349
 spring.datasource.initialization-mode=never 


### PR DESCRIPTION
In this PR we added application.properties file under test/resources to ignore the data.sql file during tests